### PR TITLE
Automatic dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.1] - 2026-02-19
+### Changed
+- Updated min sdk version to ^3.11.0
+- Updated dependencies
+
 ## [6.1.0] - 2025-11-22
 ### Changed
 - Updated min sdk version to ^3.10.0
@@ -280,6 +285,7 @@ higher version from the lockfile
 - Initial release
 - Automatic deployment
 
+[6.1.1]: https://github.com/Skycoder42/dart_pre_commit/compare/v6.1.0...v6.1.1
 [6.1.0]: https://github.com/Skycoder42/dart_pre_commit/compare/v6.0.0...v6.1.0
 [6.0.0]: https://github.com/Skycoder42/dart_pre_commit/compare/v5.4.8...v6.0.0
 [5.4.8]: https://github.com/Skycoder42/dart_pre_commit/compare/v5.4.7...v5.4.8

--- a/lib/src/di.dart
+++ b/lib/src/di.dart
@@ -5,18 +5,20 @@ import 'package:meta/meta.dart';
 import 'di.config.dart';
 import 'util/logger.dart';
 import 'util/logging/console_logger.dart';
+import 'util/logging/logging_module.dart';
 import 'util/logging/simple_logger.dart';
 
 @internal
 @InjectableInit(
   preferRelativeImports: true,
   throwOnMissingDependencies: true,
-  ignoreUnregisteredTypes: [GetIt, LogLevel],
+  ignoreUnregisteredTypes: [GetIt],
 )
 GetIt createDiContainer({
   bool useAnsiLogger = false,
   LogLevel logLevel = LogLevel.info,
 }) {
+  LogLevelFactory.logLevel = logLevel;
   final instance = GetIt.asNewInstance();
   instance
     ..registerSingleton(instance)

--- a/lib/src/tasks/analysis_task_base.dart
+++ b/lib/src/tasks/analysis_task_base.dart
@@ -40,11 +40,9 @@ sealed class AnalysisConfig with _$AnalysisConfig {
   // ignore: invalid_annotation_target
   @JsonSerializable(anyMap: true, checked: true, disallowUnrecognizedKeys: true)
   const factory AnalysisConfig({
-    // ignore: invalid_annotation_target
     @JsonKey(name: 'error-level')
     @Default(AnalyzeErrorLevel.info)
     AnalyzeErrorLevel errorLevel,
-    // ignore: invalid_annotation_target
     @JsonKey(name: 'ignore-unstaged-files')
     @Default(false)
     bool ignoreUnstagedFiles,

--- a/lib/src/tasks/format_task.dart
+++ b/lib/src/tasks/format_task.dart
@@ -15,10 +15,8 @@ sealed class FormatConfig with _$FormatConfig {
   /// @nodoc
   // ignore: invalid_annotation_target
   @JsonSerializable(anyMap: true, checked: true, disallowUnrecognizedKeys: true)
-  const factory FormatConfig({
-    // ignore: invalid_annotation_target
-    @JsonKey(name: 'line-length') int? lineLength,
-  }) = _FormatConfig;
+  const factory FormatConfig({@JsonKey(name: 'line-length') int? lineLength}) =
+      _FormatConfig;
 
   /// @nodoc
   factory FormatConfig.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/tasks/models/osv_scanner/vulnerability.dart
+++ b/lib/src/tasks/models/osv_scanner/vulnerability.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: invalid_annotation_target
-
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'vulnerability.freezed.dart';

--- a/lib/src/tasks/models/outdated/version_info.dart
+++ b/lib/src/tasks/models/outdated/version_info.dart
@@ -10,7 +10,6 @@ part 'version_info.g.dart';
 sealed class VersionInfo with _$VersionInfo {
   /// @nodoc
   const factory VersionInfo({
-    // ignore: invalid_annotation_target
     @JsonKey(
       fromJson: VersionInfo._versionFromJson,
       toJson: VersionInfo._versionToJson,

--- a/lib/src/tasks/models/pull_up_dependencies/package.dart
+++ b/lib/src/tasks/models/pull_up_dependencies/package.dart
@@ -17,7 +17,6 @@ sealed class Package with _$Package {
   )
   const factory Package({
     required String dependency,
-    // ignore: invalid_annotation_target
     @JsonKey(toJson: Package._versionToJson, fromJson: Package._versionFromJson)
     required Version version,
   }) = _Package;

--- a/lib/src/tasks/osv_scanner_task.dart
+++ b/lib/src/tasks/osv_scanner_task.dart
@@ -25,9 +25,7 @@ sealed class OsvScannerConfig with _$OsvScannerConfig {
   // ignore: invalid_annotation_target
   @JsonSerializable(anyMap: true, checked: true, disallowUnrecognizedKeys: true)
   const factory OsvScannerConfig({
-    // ignore: invalid_annotation_target
     @JsonKey(name: 'lockfile-only') @Default(true) bool lockfileOnly,
-    // ignore: invalid_annotation_target
     @JsonKey(name: 'config') String? configFile,
     @Default(false) bool legacy,
   }) = _OsvScannerConfig;

--- a/lib/src/util/logging/console_logger.dart
+++ b/lib/src/util/logging/console_logger.dart
@@ -6,6 +6,7 @@ import 'package:injectable/injectable.dart';
 import 'package:meta/meta.dart';
 
 import '../logger.dart';
+import 'logging_module.dart';
 
 @internal
 const ansiEnv = Environment('ansi');
@@ -26,7 +27,7 @@ class ConsoleLogger implements Logger {
   ///
   /// The [logLevel], which is [LogLevel.info] by default, can be adjusted to
   /// control how much is logged.
-  ConsoleLogger(this.logLevel);
+  ConsoleLogger(LogLevelFactory logLevelFactory) : logLevel = logLevelFactory();
 
   @override
   void updateStatus({

--- a/lib/src/util/logging/logging_module.dart
+++ b/lib/src/util/logging/logging_module.dart
@@ -4,6 +4,21 @@ import 'package:injectable/injectable.dart';
 import '../logger.dart';
 
 @internal
+@immutable
+@singleton
+class LogLevelFactory {
+  static LogLevel logLevel = .nothing;
+
+  LogLevelFactory([@ignoreParam LogLevel? logLevel]) {
+    if (logLevel != null) {
+      LogLevelFactory.logLevel = logLevel;
+    }
+  }
+
+  LogLevel call() => logLevel;
+}
+
+@internal
 @module
 abstract class LoggingModule {
   @singleton

--- a/lib/src/util/logging/simple_logger.dart
+++ b/lib/src/util/logging/simple_logger.dart
@@ -4,6 +4,7 @@ import 'package:injectable/injectable.dart';
 import 'package:meta/meta.dart';
 
 import '../logger.dart';
+import 'logging_module.dart';
 
 @internal
 const noAnsiEnv = Environment('noAnsi');
@@ -29,10 +30,11 @@ class SimpleLogger implements Logger {
 
   /// Default constructor.
   SimpleLogger(
-    this.logLevel, {
+    LogLevelFactory logLevelFactory, {
     @ignoreParam IOSink? outSink,
     @ignoreParam IOSink? errSink,
-  }) : outSink = outSink ?? stdout,
+  }) : logLevel = logLevelFactory(),
+       outSink = outSink ?? stdout,
        errSink = errSink ?? stderr;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: dart_pre_commit
 description: A small collection of pre commit hooks to format and lint dart code
-version: 6.1.0
+version: 6.1.1
 homepage: https://github.com/Skycoder42/dart_pre_commit
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 platforms:
   linux:
@@ -15,16 +15,16 @@ executables:
   dart_pre_commit: dart_pre_commit
 
 dependencies:
-  analyzer: ">=8.4.0 <10.0.0"
+  analyzer: ^9.0.0
   args: ^2.7.0
   checked_yaml: ^2.0.4
   console: ^4.1.0
   convert: ^3.1.2
   crypto: ^3.0.7
   freezed_annotation: ^3.1.0
-  get_it: ^9.1.0
-  injectable: ^2.6.0
-  json_annotation: ^4.9.0
+  get_it: ^9.2.0
+  injectable: ^2.7.1+4
+  json_annotation: ^4.10.0
   logging: ^1.3.0
   meta: ^1.17.0
   path: ^1.9.1
@@ -33,15 +33,15 @@ dependencies:
   yaml: ^3.1.3
 
 dev_dependencies:
-  build_runner: ^2.10.4
+  build_runner: ^2.11.1
   coverage: ^1.15.0
-  dart_test_tools: ^7.0.1
-  freezed: ^3.2.3
-  injectable_generator: ^2.9.1
-  json_serializable: ^6.11.2
+  dart_test_tools: ^7.0.2
+  freezed: ^3.2.5
+  injectable_generator: ^2.12.0
+  json_serializable: ^6.12.0
   mocktail: ^1.0.4
-  test: ^1.28.0
-  yaml_edit: ^2.2.2
+  test: ^1.29.0
+  yaml_edit: ^2.2.4
 
 cider:
   link_template:

--- a/test/unit/util/logging/console_logger_test.dart
+++ b/test/unit/util/logging/console_logger_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:console/console.dart';
 import 'package:dart_pre_commit/src/util/logger.dart';
 import 'package:dart_pre_commit/src/util/logging/console_logger.dart';
+import 'package:dart_pre_commit/src/util/logging/logging_module.dart';
 import 'package:dart_test_tools/test.dart';
 import 'package:test/test.dart';
 
@@ -27,7 +28,7 @@ void main() {
   setUp(() {
     output.clear();
 
-    sut = ConsoleLogger(LogLevel.debug);
+    sut = ConsoleLogger(LogLevelFactory(.debug));
   });
 
   group('updateStatus', () {
@@ -174,7 +175,7 @@ void main() {
         (LogLevel.nothing, (l) => l.except(Exception()), null),
       ],
       (fixture) {
-        sut = ConsoleLogger(fixture.$1);
+        sut = ConsoleLogger(LogLevelFactory(fixture.$1));
 
         fixture.$2?.call(sut);
         expect(output.toString(), isEmpty);

--- a/test/unit/util/logging/simple_logger_test.dart
+++ b/test/unit/util/logging/simple_logger_test.dart
@@ -3,6 +3,7 @@
 import 'dart:io';
 
 import 'package:dart_pre_commit/src/util/logger.dart';
+import 'package:dart_pre_commit/src/util/logging/logging_module.dart';
 import 'package:dart_pre_commit/src/util/logging/simple_logger.dart';
 import 'package:dart_test_tools/test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -23,12 +24,12 @@ void main() {
     sut = SimpleLogger(
       outSink: mockOutSink,
       errSink: mockErrSink,
-      LogLevel.debug,
+      LogLevelFactory(.debug),
     );
   });
 
   test('uses stdout and stderr by default', () {
-    sut = SimpleLogger(LogLevel.debug);
+    sut = SimpleLogger(LogLevelFactory(.debug));
 
     expect(sut.outSink, same(stdout));
     expect(sut.errSink, same(stderr));
@@ -176,7 +177,7 @@ void main() {
         sut = SimpleLogger(
           outSink: mockOutSink,
           errSink: mockErrSink,
-          fixture.$1,
+          LogLevelFactory(fixture.$1),
         );
 
         fixture.$2?.call(sut);


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for dart_pre_commit to ^3.11.0
### Dependency Updates
```

Changed 11 constraints in pubspec.yaml:
  analyzer: >=8.4.0 <10.0.0 -> ^9.0.0
  get_it: ^9.1.0 -> ^9.2.0
  injectable: ^2.6.0 -> ^2.7.1+4
  json_annotation: ^4.9.0 -> ^4.10.0
  build_runner: ^2.10.4 -> ^2.11.1
  dart_test_tools: ^7.0.1 -> ^7.0.2
  freezed: ^3.2.3 -> ^3.2.5
  injectable_generator: ^2.9.1 -> ^2.12.0
  json_serializable: ^6.11.2 -> ^6.12.0
  test: ^1.28.0 -> ^1.29.0
  yaml_edit: ^2.2.2 -> ^2.2.4
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 92.0.0 (95.0.0 available)
  analysis_server_plugin 0.3.4 (0.3.9 available)
  analyzer 9.0.0 (10.1.0 available)
  analyzer_plugin 0.13.11 (0.14.3 available)
  dart_style 3.1.3 (3.1.5 available)
  lean_builder 0.1.6 (0.1.7 available)
  meta 1.17.0 (1.18.1 available)
  watcher 1.1.4 (1.2.1 available)
No dependencies changed.
8 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
